### PR TITLE
[BUGFIX] Handle non-supported library versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up environment
+      - name: Set up stable environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
@@ -88,7 +88,7 @@ jobs:
           config: tests/fixtures/cache-warmup.json
           limit: 10
 
-      - name: Test with explicit stable version
+      - name: Test with stable version
         id: stable
         uses: ./
         env:
@@ -99,11 +99,42 @@ jobs:
           sitemaps: https://cache-warmup.dev/sitemap.xml
           limit: 10
 
-      - name: Test with explicit legacy version
+      - name: Test with legacy version
         id: legacy
         uses: ./
         with:
           version: 2.6.0
+          sitemaps: https://cache-warmup.dev/sitemap.xml
+          limit: 10
+
+      - name: Set up lowest environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          coverage: none
+
+      - name: Test with lowest version
+        id: lowest
+        uses: ./
+        with:
+          version: 0.7.0
+          sitemaps: https://cache-warmup.dev/sitemap.xml
+          limit: 10
+
+      - name: Test with lowest signed version
+        id: lowest-signed
+        uses: ./
+        with:
+          version: 0.7.6
+          sitemaps: https://cache-warmup.dev/sitemap.xml
+          limit: 10
+
+      - name: Test with unsupported version
+        id: unsupported
+        continue-on-error: true
+        uses: ./
+        with:
+          version: 0.1.0
           sitemaps: https://cache-warmup.dev/sitemap.xml
           limit: 10
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Read more in the [official documentation](https://cache-warmup.dev/).
 
 ## 🔥 Usage
 
+> [!IMPORTANT]
+> The action requires at least version **0.7.0** of the `cache-warmup` library.
+
 Create a new workflow or add a new step to your existing workflow:
 
 ```yaml
@@ -57,7 +60,7 @@ The following inputs are currently available:
 
 | Name        | Description                                                                               | Default  | Required |
 |-------------|-------------------------------------------------------------------------------------------|----------|----------|
-| `version`   | Version of the `cache-warmup` library to use                                              | `latest` | ✅        |
+| `version`   | Version of the `cache-warmup` library to use (must be at least `0.7.0`)                   | `latest` | ✅        |
 | `sitemaps`  | URLs or local filenames of XML sitemaps to be warmed up, separated by newline             | –        | –        |
 | `urls`      | Additional URLs to be warmed up, separated by newline                                     | –        | –        |
 | `limit`     | Limit the number of URLs to be processed                                                  | `0`      | –        |

--- a/bin/main.sh
+++ b/bin/main.sh
@@ -56,16 +56,19 @@ function check_requirements() {
 
 # Download and verify PHAR file from GitHub release
 function download_phar_file() {
-    # Download PHAR
-    curl -sSL "${sourceUrl}" -o "${pharFile}"
+    # Download PHAR file
+    if ! curl -fsSL "${sourceUrl}" -o "${pharFile}" 2>/dev/null; then
+        error "Download failed" "Unable to download PHAR file from \"${sourceUrl}\"."
+    fi
+
+    # Make PHAR file executable
     chmod +x "${pharFile}"
 
-    # Download signature
-    curl -sSL "${signatureUrl}" -o "${signatureFile}"
-
-    # Verify PHAR file
-    gpg --keyserver keys.openpgp.org --recv-keys E73F20790A629A2CEF2E9AE57C1C5363490E851E 2>/dev/null
-    gpg --verify "${signatureFile}" "${pharFile}" 2>/dev/null
+    # Download signature file and verify PHAR file
+    if curl -fsSL "${signatureUrl}" -o "${signatureFile}" 2>/dev/null; then
+        gpg --keyserver keys.openpgp.org --recv-keys E73F20790A629A2CEF2E9AE57C1C5363490E851E 2>/dev/null
+        gpg --verify "${signatureFile}" "${pharFile}" 2>/dev/null
+    fi
 
     # Resolve library version from PHAR file
     if [ "${version}" == "latest" ]; then


### PR DESCRIPTION
This PR adds tests to handle unsupported library versions. In addition, versions without a signature file can now be used as well.